### PR TITLE
Fix: Correct directive usage and simplify change detection

### DIFF
--- a/client/src/app/pages/home-page/home-page.component.html
+++ b/client/src/app/pages/home-page/home-page.component.html
@@ -3,7 +3,7 @@
     <mat-card-header>
       <mat-card-title>Shorten a long URL</mat-card-title>
     </mat-card-header>
-      <form [formControl]="longUrlForm" (ngSubmit)="onSubmit()">
+      <form (ngSubmit)="onSubmit()">
         <mat-card-content class="home-card-content">
           <mat-form-field appearance="outline">
             <mat-label>Long URL</mat-label>

--- a/client/src/app/pages/home-page/home-page.component.ts
+++ b/client/src/app/pages/home-page/home-page.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, signal} from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
@@ -39,8 +39,7 @@ export class HomePageComponent {
 
   constructor(
     private apiService: ApiService,
-    private snackBar: MatSnackBar,
-    private cdr: ChangeDetectorRef,
+    private snackBar: MatSnackBar
   ) {
     scheduled([of(this.longUrlForm.statusChanges, this.longUrlForm.valueChanges)], asyncScheduler)
       .pipe(takeUntilDestroyed())
@@ -67,7 +66,7 @@ export class HomePageComponent {
     })
   }
 
-  public updateErrorMessage() {
+  public updateErrorMessage(): void {
     if (this.longUrlForm.hasError('required')) {
       this.errorMessage.set('You must enter a value');
     } else if (this.longUrlForm.hasError('pattern')) {
@@ -83,6 +82,5 @@ export class HomePageComponent {
 
   public resetCardContent(): void {
     this.shortLink.set(null);
-    this.cdr.detectChanges();
   }
 }


### PR DESCRIPTION
This PR addresses a console error (`NG01203: No value accessor`) caused by an incorrect `[formControl]` directive on the main `<form>` element.

- The incorrect directive has been removed from the `<form>` tag in `home-page.component.html`.
- A happy side effect of fixing this is that the manual call to `this.cdr.detectChanges()` is no longer required to fix the `mat-form-field` styling on reset. This manual call has been removed.