### PR TITLE
Feature: Dashboard

### DIFF
--- a/api/src/links/links.controller.ts
+++ b/api/src/links/links.controller.ts
@@ -1,11 +1,22 @@
-import { Controller, Get, Post, Body, Param, Res, ParseFilePipe, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Res,
+  HttpStatus,
+  Query,
+  DefaultValuePipe,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { LinksService } from './links.service';
 import { CreateLinkDto } from './dto/create-link.dto';
 import type { Response } from 'express';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
 
 @ApiTags('Links')
-@Controller()
+@Controller('links')
 export class LinksController {
   constructor(private readonly linkService: LinksService) {}
 
@@ -15,10 +26,40 @@ export class LinksController {
   })
   @ApiResponse({ status: HttpStatus.CREATED, description: 'The link was successfully created' })
   @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'The provided URL was invalid' })
-  @Post('links')
+  @Post()
   async create(@Body() createLinkDto: CreateLinkDto) {
     const link = await this.linkService.create(createLinkDto);
     return link;
+  }
+
+  @ApiOperation({
+    summary: 'Retrieve a paginated list of links',
+    description: 'Fetches a list of all created links, sorted by creation date in descending order. Supports pagination',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    default: 1,
+    example: 5,
+    description: 'The page number to retrieve'
+  })
+  @ApiQuery({
+    name: 'pageSize',
+    required: false,
+    type: Number,
+    default: 10,
+    example: 7,
+    description: 'The number of items per page'
+  })
+  @ApiResponse({ status: HttpStatus.OK, description: 'A paginated list of links has been successfully retrieved' })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'The query parameters are not valid integers' })
+  @Get()
+  async findAll(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('pageSize', new DefaultValuePipe(10), ParseIntPipe) pageSize: number,
+  ) {
+    return await this.linkService.findAll({ page, pageSize });
   }
 
   @ApiOperation({
@@ -41,4 +82,5 @@ export class LinksController {
     const link = await this.linkService.findOne(shortCode);
     return res.redirect(HttpStatus.MOVED_PERMANENTLY, link.longUrl);
   }
+
 }

--- a/api/src/links/links.service.ts
+++ b/api/src/links/links.service.ts
@@ -3,6 +3,11 @@ import { PrismaService } from '../prisma.service';
 import { nanoid } from 'nanoid';
 import { CreateLinkDto } from './dto/create-link.dto';
 
+export interface FindAllLinksOptions {
+  page: number;
+  pageSize: number;
+}
+
 @Injectable()
 export class LinksService {
   constructor(private readonly prisma: PrismaService) {}
@@ -31,4 +36,23 @@ export class LinksService {
 
     return link;
   }
+
+  async findAll(options: FindAllLinksOptions) {
+    const { page, pageSize } = options;
+    const skip = (page - 1) * pageSize;
+
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.link.findMany({
+        skip: skip,
+        take: pageSize,
+        orderBy: {
+          createdAt: 'desc'
+        },
+      }),
+      this.prisma.link.count(),
+    ]);
+
+    return { items, total };
+  }
+
 }

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,8 +1,8 @@
-<mat-toolbar color="primary">
+<mat-toolbar>
   <span>🚀 LinkLoom</span>
   <span class="spacer"></span>
-  <a mat-button routerLink="/">Home</a>
-  <a mat-button routerLink="/dashboard">Dashboard</a>
+  <a matButton="text" routerLink="/">Home</a>
+  <a matButton="text" routerLink="/dashboard">Dashboard</a>
 </mat-toolbar>
 
 <main class="content">

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -1,0 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
+.spacer {
+  flex: 1 1 auto;
+}

--- a/client/src/app/pages/dashboard-page/dashboard-page.component.html
+++ b/client/src/app/pages/dashboard-page/dashboard-page.component.html
@@ -1,1 +1,77 @@
-<p>dashboard-page works!</p>
+<div class="dashboard-container">
+  @if (isLoading()) {
+    <div class="state-container">
+      <mat-spinner></mat-spinner>
+    </div>
+  }
+
+  @if (!isLoading()) {
+    @if (totalLinks() === 0) {
+      <div class="state-container no-links">
+        You haven't created any links yet. Go Loom one!
+      </div>
+    }
+
+    @if (totalLinks() > 0) {
+      <div class="link-grid">
+        @for (link of links(); track link.id) {
+          <mat-card class="link-card">
+            <mat-card-content class="link-card-content">
+              <div class="info-container">
+                <div class="info-header">
+                  <mat-icon>link</mat-icon>
+                  <span>Original URL</span>
+                </div>
+                <span class="url">{{ link.longUrl }}</span>
+              </div>
+              <mat-divider></mat-divider>
+              <div class="info-container">
+                <div class="info-header">
+                  <mat-icon>shortcut</mat-icon>
+                  <span>Short URL</span>
+                </div>
+                <div class="short-url-container">
+                  <a
+                    class="url"
+                    [href]="baseUrl + '/' + link.shortCode"
+                    target="_blank"
+                  >
+                    {{ baseUrl }}/{{ link.shortCode }}
+                  </a>
+                </div>
+              </div>
+            </mat-card-content>
+
+            <mat-card-actions align="end">
+              <button
+                mat-icon-button
+                matTooltip="Copy short URL"
+                [cdkCopyToClipboard]="baseUrl + '/' + link.shortCode"
+                (cdkCopyToClipboardCopied)="onCopy()"
+              >
+                <mat-icon>content_copy</mat-icon>
+              </button>
+              <button
+                mat-icon-button
+                matTooltip="Delete forever"
+                (click)="onDeleteForever(link.id)"
+              >
+                <mat-icon>delete_forever</mat-icon>
+              </button>
+            </mat-card-actions>
+          </mat-card>
+        }
+      </div>
+      <mat-paginator
+        class="dashboard-paginator"
+        [length]="totalLinks()"
+        [pageIndex]="pageIndex()"
+        [pageSize]="pageSize()"
+        [pageSizeOptions]="[5, 10, 25, 50]"
+        (page)="onPageChange($event)"
+        showFirstLastButtons
+      >
+      </mat-paginator>
+    }
+  }
+</div>

--- a/client/src/app/pages/dashboard-page/dashboard-page.component.scss
+++ b/client/src/app/pages/dashboard-page/dashboard-page.component.scss
@@ -1,0 +1,73 @@
+@use '@angular/material' as mat;
+
+.dashboard-container {
+  height: calc(100dvh - 96px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 16px;
+}
+
+.state-container {
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.no-links {
+  font: var(--mat-sys-headline-medium);
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.link-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 16px;
+}
+
+.link-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.info-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.info-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font: var(--mat-sys-title-large);
+  font-weight: 500;
+}
+
+.url {
+  font: var(--mat-sys-title-medium);
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.short-url-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  a {
+    color: var(--mat-sys-primary);
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.dashboard-paginator {
+  margin-top: 16px;
+}

--- a/client/src/app/pages/dashboard-page/dashboard-page.component.ts
+++ b/client/src/app/pages/dashboard-page/dashboard-page.component.ts
@@ -1,11 +1,83 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, signal } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatListModule } from '@angular/material/list';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import { ClipboardModule } from '@angular/cdk/clipboard';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
+import { ApiService, Link } from '../../services/api.service';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-dashboard-page',
-  imports: [],
+  standalone: true,
+  imports: [
+    MatCardModule,
+    MatPaginatorModule,
+    MatListModule,
+    MatProgressSpinnerModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    MatDialogModule,
+    ClipboardModule,
+    MatIcon,
+    MatTooltip
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './dashboard-page.component.html',
   styleUrl: './dashboard-page.component.scss'
 })
-export class DashboardPageComponent {
+export class DashboardPageComponent implements OnInit {
+  public links = signal<Link[]>([]);
+  public totalLinks = signal(0);
+  public pageIndex = signal(0);
+  public pageSize = signal(10);
+  public isLoading = signal(true);
+  public baseUrl = window.location.origin + '/links';
 
+  constructor(
+    private apiService: ApiService,
+    private snackBar: MatSnackBar,
+    private dialog: MatDialog
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.fetchLinks();
+  }
+
+  fetchLinks(): void {
+    this.isLoading.set(true);
+    this.apiService
+      .getAllLinks(this.pageIndex() + 1, this.pageSize())
+      .subscribe({
+        next: (response) => {
+          this.links.set(response.items);
+          this.totalLinks.set(response.total);
+          this.isLoading.set(false);
+        },
+        error: (error) => {
+          console.error('Error fetching links:', error);
+          this.snackBar.open('Could not fetch links. Please try again', 'Close', {duration: 5000});
+          this.isLoading.set(false);
+        },
+      });
+  }
+
+  onPageChange(event: PageEvent): void {
+    this.pageIndex.set(event.pageIndex);
+    this.pageSize.set(event.pageSize);
+    this.fetchLinks();
+  }
+
+  onCopy(): void {
+    this.snackBar.open('Copied!', 'Close', {duration: 2000});
+  }
+
+  onDeleteForever(id: number): void {
+    return;
+  }
 }

--- a/client/src/app/pages/home-page/home-page.component.html
+++ b/client/src/app/pages/home-page/home-page.component.html
@@ -1,14 +1,17 @@
-<mat-card class="home-card">
-  @if (!shortLink()) {
-    <mat-card-header>
-      <mat-card-title>Shorten a long URL</mat-card-title>
-    </mat-card-header>
+<div class="home-container">
+  <mat-card class="home-card">
+    @if (!shortLink()) {
+      <mat-card-header>
+        <mat-card-title class="home-card-title">Shorten long URL</mat-card-title>
+      </mat-card-header>
       <form (ngSubmit)="onSubmit()">
         <mat-card-content class="home-card-content">
-          <mat-form-field appearance="outline">
+          <mat-form-field
+            appearance="outline"
+            hideRequiredMarker
+          >
             <mat-label>Long URL</mat-label>
             <input
-              id="long-url-input"
               matInput
               type="url"
               placeholder="https://example.com/very/long/example"
@@ -18,19 +21,19 @@
             />
             @if (longUrlForm.value) {
               <button
-                mat-icon-button
+                matIconButton
                 matSuffix
+                matTooltip="Clear"
                 (click)="longUrlForm.reset()"
               >
                 <mat-icon>close</mat-icon>
               </button>
             }
             <mat-hint align="start">A valid URL (starting with https://)</mat-hint>
-            <mat-error>{{errorMessage()}}</mat-error>
+            <mat-error>{{ errorMessage() }}</mat-error>
           </mat-form-field>
           <button
-            mat-raised-button
-            color="primary"
+            matButton="filled"
             type="submit"
             [disabled]="longUrlForm.invalid"
           >
@@ -38,35 +41,35 @@
           </button>
         </mat-card-content>
       </form>
-  }
-  @if (shortLink()) {
-    <mat-card-header>
-      <mat-card-title>Your link is ready!</mat-card-title>
-    </mat-card-header>
-    <mat-card-content class="home-card-content">
-      <div class="short-link-display">
-        <a
-          [href]="baseUrl + '/' + shortLink()!.shortCode"
-          target="_blank"
-        >
-          {{ baseUrl }}/{{ shortLink()!.shortCode }}
-        </a>
+    }
+    @if (shortLink()) {
+      <mat-card-header>
+        <mat-card-title class="home-card-title">Your link is ready!</mat-card-title>
+      </mat-card-header>
+      <mat-card-content class="home-card-content">
+        <div class="short-link-container">
+          <a
+            [href]="baseUrl + '/' + shortLink()!.shortCode"
+            target="_blank"
+          >
+            {{ baseUrl }}/{{ shortLink()!.shortCode }}
+          </a>
+          <button
+            matIconButton
+            matTooltip="Copy to clipboard"
+            [cdkCopyToClipboard]="baseUrl +'/' + shortLink()!.shortCode"
+            (cdkCopyToClipboardCopied)="onCopy()"
+          >
+            <mat-icon>content_copy</mat-icon>
+          </button>
+        </div>
         <button
-          mat-icon-button
-          matTooltip="Copy to clipboard"
-          [cdkCopyToClipboard]="baseUrl +'/' + shortLink()!.shortCode"
-          (cdkCopyToClipboardCopied)="onCopy()"
+          matButton="outlined"
+          (click)="resetCardContent()"
         >
-          <mat-icon>content_copy</mat-icon>
+          Shorten another link
         </button>
-      </div>
-      <button
-        mat-stroked-button
-        color="accent"
-        (click)="resetCardContent()"
-      >
-        Shorten another link
-      </button>
-    </mat-card-content>
-  }
-</mat-card>
+      </mat-card-content>
+    }
+  </mat-card>
+</div>

--- a/client/src/app/pages/home-page/home-page.component.scss
+++ b/client/src/app/pages/home-page/home-page.component.scss
@@ -1,20 +1,19 @@
 @use '@angular/material' as mat;
 
-.home-card {
-  height: 210px;
-  width: 420px;
+.home-container {
+  height: calc(100dvh - 64px);
   display: flex;
-  flex-direction: column;
   justify-content: center;
+  align-items: center;
+}
 
-  @include mat.card-overrides((
-    title-text-size: 1.5rem,
-    title-text-weight: 500
-  ));
+.home-card {
+  width: 75dvw;
+}
 
-  @include mat.form-field-overrides((
-    outlined-input-text-placeholder-color: rgba(255, 255, 255, 0.5)
-  ));
+.home-card-title {
+  font: var(--mat-sys-headline-medium);
+  font-weight: 500;
 }
 
 .home-card-content {
@@ -24,22 +23,22 @@
   gap: 16px;
 }
 
-.short-link-display {
+.short-link-container {
+  height: 52px;
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 16px;
-  background-color: rgba(255, 255, 255, 0.05);
-  margin-top: 14px;
-  margin-bottom: 14px;
+  background-color: var(--mat-sys-background);
   padding: 12px 16px;
   border-radius: 4px;
+  margin-top: 16px;
 }
 
 a {
-  color: lightblue;
-  text-decoration: none;
+  color: var(--mat-sys-primary);
+  font: var(--mat-sys-headline-small);
   font-family: monospace;
-  font-size: 1.1rem;
+  text-decoration: none;
   flex-grow: 1;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/client/src/app/pages/home-page/home-page.component.ts
+++ b/client/src/app/pages/home-page/home-page.component.ts
@@ -35,7 +35,7 @@ export class HomePageComponent {
   public longUrlForm = new FormControl('', [Validators.required, Validators.pattern('(https?://.+)')]);
   public errorMessage = signal('');
   public shortLink = signal<Link | null>(null);
-  public baseUrl = window.location.origin;
+  public baseUrl = window.location.origin + '/links';
 
   constructor(
     private apiService: ApiService,

--- a/client/src/app/pages/home-page/home-page.component.ts
+++ b/client/src/app/pages/home-page/home-page.component.ts
@@ -46,7 +46,7 @@ export class HomePageComponent {
       .subscribe(() => this.updateErrorMessage());
   }
 
-  public onSubmit(): void {
+  onSubmit(): void {
     if (this.longUrlForm.invalid) {
       return;
     }
@@ -66,7 +66,7 @@ export class HomePageComponent {
     })
   }
 
-  public updateErrorMessage(): void {
+  updateErrorMessage(): void {
     if (this.longUrlForm.hasError('required')) {
       this.errorMessage.set('You must enter a value');
     } else if (this.longUrlForm.hasError('pattern')) {
@@ -76,11 +76,11 @@ export class HomePageComponent {
     }
   }
 
-  public onCopy(): void {
+  onCopy(): void {
     this.snackBar.open('Copied!', 'Close', { duration: 2000 });
   }
 
-  public resetCardContent(): void {
+  resetCardContent(): void {
     this.shortLink.set(null);
   }
 }

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -10,6 +10,11 @@ export interface Link {
   createdAt: string;
 }
 
+export interface PaginatedLinksResponse {
+  items: Link[];
+  total: number;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -18,5 +23,14 @@ export class ApiService {
 
   public createLink(longUrl: string): Observable<Link> {
     return this.http.post<Link>('/api/links', { longUrl });
+  }
+
+  public getAllLinks(page: number, pageSize: number): Observable<PaginatedLinksResponse> {
+    return this.http.get<PaginatedLinksResponse>('/api/links', {
+      params: {
+        page: page.toString(),
+        pageSize: pageSize.toString(),
+      },
+    });
   }
 }

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -1,10 +1,8 @@
-
-// Include theming for Angular Material with `mat.theme()`.
-// This Sass mixin will define CSS variables that are used for styling Angular Material
-// components according to the Material 3 design spec.
-// Learn more about theming and how to use it for your application's
-// custom components at https://material.angular.dev/guide/theming
 @use '@angular/material' as mat;
+
+html, body {
+  height: 100%;
+}
 
 html {
   @include mat.theme((
@@ -18,40 +16,9 @@ html {
 }
 
 body {
-  // Default the application to a light color theme. This can be changed to
-  // `dark` to enable the dark color theme, or to `light dark` to defer to the
-  // user's system settings.
   color-scheme: light dark;
-
-  // Set a default background, font and text colors for the application using
-  // Angular Material's system-level CSS variables. Learn more about these
-  // variables at https://material.angular.dev/guide/system-variables
   background-color: var(--mat-sys-surface);
   color: var(--mat-sys-on-surface);
   font: var(--mat-sys-body-medium);
-
-  // Reset the user agent margin.
   margin: 0;
-}
-/* You can add global styles to this file, and also import other style files */
-
-html, body {
-  height: 100%;
-}
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-
-* {
-  box-sizing: border-box;
-}
-
-.spacer {
-  flex: 1 1 auto;
-}
-
-.content {
-  padding: 24px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: calc(100vh - 64px);
 }


### PR DESCRIPTION
This PR introduces the paginated dashboard for viewing created links.

Backend:
- A new, paginated endpoint at `GET /links` has been created.
- The endpoint uses a Prisma transaction for efficient querying.
- A routing conflict with the `GET /:shortCode` endpoint was resolved by moving all endpoints under the `/links` resource path.

Frontend:
- The dashboard is a responsive CSS Grid that displays each link as a separate `mat-card`.
- The `mat-paginator` component is fully integrated, allowing users to navigate through their links.
- The SCSS uses the latest features, including `dvh` units for better mobile layouts and Material 3's CSS Custom Properties (`var(-mat-sys-...)`) for perfect theme consistency.
- All component state (links, totals, loading status) is managed by Angular Signals, 
- The UI includes clear loading and empty states, as well as tooltips and copy-to-clipboard functionality on each card.

Closes #4