### PR TITLE
Feature: Link Deletion

### DIFF
--- a/api/src/links/links.controller.ts
+++ b/api/src/links/links.controller.ts
@@ -2,12 +2,13 @@ import {
   Body,
   Controller,
   DefaultValuePipe,
-  Get,
+  Delete,
+  Get, HttpCode,
   HttpStatus,
   Param,
   ParseIntPipe,
   Post,
-  Query
+  Query,
 } from '@nestjs/common';
 import { LinksService } from './links.service';
 import { CreateLinkDto } from './dto/create-link.dto';
@@ -100,5 +101,23 @@ export class LinksController {
   @Get(':shortCode')
   async redirect(@Param('shortCode') shortCode: string) {
     return await this.linkService.findOne(shortCode);
+  }
+
+  @ApiOperation({
+    summary: 'Delete a link by its ID',
+    description: 'Permanently deletes a link from the database',
+  })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'The link was successfully deleted',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'The link with the specified ID does not exist',
+  })
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async delete(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this.linkService.delete(id);
   }
 }

--- a/api/src/links/links.controller.ts
+++ b/api/src/links/links.controller.ts
@@ -107,6 +107,12 @@ export class LinksController {
     summary: 'Delete a link by its ID',
     description: 'Permanently deletes a link from the database',
   })
+  @ApiParam({
+    name: 'id',
+    type: Number,
+    description: 'The ID of the link to delete',
+    example: 228
+  })
   @ApiResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'The link was successfully deleted',

--- a/api/src/links/links.service.ts
+++ b/api/src/links/links.service.ts
@@ -13,16 +13,14 @@ export class LinksService {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(createLinkDto: CreateLinkDto) {
-    const shortCode = nanoid(7)
+    const shortCode = nanoid(7);
 
-    const newLink = await this.prisma.link.create({
+    return this.prisma.link.create({
       data: {
         longUrl: createLinkDto.longUrl,
         shortCode: shortCode,
       },
     });
-
-    return newLink;
   }
 
   async findOne(shortCode: string) {
@@ -46,7 +44,7 @@ export class LinksService {
         skip: skip,
         take: pageSize,
         orderBy: {
-          createdAt: 'desc'
+          createdAt: 'desc',
         },
       }),
       this.prisma.link.count(),
@@ -55,4 +53,14 @@ export class LinksService {
     return { items, total };
   }
 
+  async delete(id: number) {
+    const link = await this.prisma.link.findUnique({ where: { id } });
+    if (!link) {
+      throw new NotFoundException(`Link with ID ${id} not found`);
+    }
+
+    return this.prisma.link.delete({
+      where: { id },
+    });
+  }
 }

--- a/client/src/app/components/confirmation-dialog/confirmation-dialog.component.html
+++ b/client/src/app/components/confirmation-dialog/confirmation-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>{{ data.title }}</h2>
+<mat-dialog-content>
+  {{ data.message }}
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button matButton mat-dialog-close>Cancel</button>
+  <button matButton [mat-dialog-close]="true" cdkFocusInitial>{{ data.action }}</button>
+</mat-dialog-actions>

--- a/client/src/app/components/confirmation-dialog/confirmation-dialog.component.ts
+++ b/client/src/app/components/confirmation-dialog/confirmation-dialog.component.ts
@@ -1,0 +1,37 @@
+import {
+  Component,
+  Inject
+} from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogTitle
+} from '@angular/material/dialog';
+import { MatButton } from '@angular/material/button';
+
+export interface ConfirmationDialogData {
+  title: string;
+  message: string;
+  action: string;
+}
+
+@Component({
+  selector: 'app-confirmation-dialog',
+  standalone: true,
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatButton
+  ],
+  templateUrl: './confirmation-dialog.component.html',
+  styleUrl: './confirmation-dialog.component.scss'
+})
+export class ConfirmationDialogComponent {
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: ConfirmationDialogData
+  ) {}
+}

--- a/client/src/app/pages/dashboard/dashboard.component.html
+++ b/client/src/app/pages/dashboard/dashboard.component.html
@@ -54,7 +54,7 @@
               <button
                 mat-icon-button
                 matTooltip="Delete forever"
-                (click)="onDeleteForever(link.id)"
+                (click)="onDeleteForever(link)"
               >
                 <mat-icon>delete_forever</mat-icon>
               </button>

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -37,4 +37,8 @@ export class ApiService {
   public getLinkByShortCode(shortCode: string): Observable<Link> {
     return this.http.get<Link>(`/api/links/${shortCode}`);
   }
+
+  public deleteLink(id: number): Observable<void> {
+    return this.http.delete<void>(`/api/links/${id}`);
+  }
 }


### PR DESCRIPTION
This PR delivers the full-stack implementation for the link deletion feature, allowing users to permanently remove their shortened links.

Backend:
- A new `DELETE /links/:id` endpoint has been created to handle the deletion logic.
- Upon successful deletion, the API returns a `204 No Content` response, adhering to REST best practices.
- Includes full Swagger documentation for the new endpoint.

Frontend:
- A new `ConfirmationDialogComponent` has been built to ensure users confirm this destructive action.
- The `DashboardComponent` now orchestrates the deletion flow: opening the dialog, calling the `ApiService`, and handling the response.
- For a smooth UX, the link is removed from the dashboard view immediately upon a successful API response, without needing a full data re-fetch.
- The component is smart enough to detect when the last item on a page other than the first one is deleted and will automatically navigate to the previous page.

Closes #15