### PR TITLE
Fix: Issues with `settings.component.ts` and `theme.service.ts`

### DIFF
--- a/client/src/app/pages/settings/settings.component.ts
+++ b/client/src/app/pages/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import {ChangeDetectionStrategy, Component, WritableSignal} from '@angular/core';
 import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
 import { ThemePreference, ThemeService } from '../../services/theme.service';
 import { FormsModule } from '@angular/forms';
@@ -20,13 +20,13 @@ import {
     MatExpansionPanel,
     MatExpansionPanelHeader,
     MatExpansionPanelTitle,
-
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './settings.component.html',
   styleUrl: './settings.component.scss'
 })
 export class SettingsComponent {
-  public selectedTheme;
+  public selectedTheme: WritableSignal<ThemePreference>;
 
   constructor(private themeService: ThemeService) {
     this.selectedTheme = themeService.preference;

--- a/client/src/app/services/theme.service.ts
+++ b/client/src/app/services/theme.service.ts
@@ -23,12 +23,23 @@ export class ThemeService {
 
   public setPreference(preference: ThemePreference): void {
     this.preference.set(preference);
-    localStorage.setItem('linkloom-theme-preference', this.preference());
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(this.themePreferenceLocalStorageKey, this.preference());
+    }
     this.applyTheme(this.preference());
   }
 
   private getInitialPreference(): ThemePreference {
-    return (localStorage.getItem(this.themePreferenceLocalStorageKey) as ThemePreference) || 'system';
+    if (typeof localStorage === 'undefined') {
+      return 'system';
+    }
+
+    const storedPreference = (localStorage.getItem(this.themePreferenceLocalStorageKey) as ThemePreference) || 'system';
+    if (storedPreference === 'light' || storedPreference === 'dark' || storedPreference === 'system') {
+      return storedPreference;
+    }
+
+    return 'system';
   }
 
   private applyTheme(theme: ThemePreference): void {


### PR DESCRIPTION
This PR addresses several issues with `settings.component.ts` and `theme.service.ts`, which were described by gemini-code-assist in #20.

- Checks were added to ensure `localStorage` is available before attempting to read from it/write to it.
- Validation of the value read from `localStorage` was added to make sure it's either `light` or `dark` or `system`.
- Missing `ChangeDetectionStrategy.OnPush` was added.
- Explicit type for `selectedTheme` was added.